### PR TITLE
New options and bufixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
 					</li>
 					<li class="grid__item" id="demo-mouseMoveWatcher">
 						<div class="grid__img grid__img--border">
-							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : "#demo-mouseMoveWatcher" } }' alt="grid01" />
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : "#demo-mouseMoveWatcher" } }' alt="grid01" />
 						</div>
 						<div class="grid__item-title">
 						Demo element.mouseMoveWatcher. Options:

--- a/index.html
+++ b/index.html
@@ -223,6 +223,12 @@
 						<p>The opacity value for the background-image divisions</p>
 						<p><code>opacity : 0.7</code></p>
 					</dd>
+					<dt><strong>customImgsOpacity</strong></dt>
+					<dd>
+						<p>The customImgsOpacity make possible set custom opacity for each layer as array of opacity values.</p>
+						<p>If length of customImgsOpacity less then layers created then script will use option "opacity"</p>
+						<p><code>customImgsOpacity : false</code></p>
+					</dd>
 					<dt><strong>bgfixed</strong></dt>
 					<dd>
 						<p>Movement of first layer; by default it's not moving</p>

--- a/index.html
+++ b/index.html
@@ -181,6 +181,27 @@
 }</code></pre>
 						</div>
 					</li>
+					<li class="grid__item">
+						<div class="grid__img grid__img--border">
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "customImgsOpacity" : [0.2, 0.5, 0.03], "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 } }' alt="grid01" />
+						</div>
+						<div class="grid__item-title">
+						Demo customImgsOpacity. Options:
+<pre><code>"extraImgs" : 2,
+"opacity" : 0.7,
+"bgfixed" : false,
+"customImgsOpacity" : [0.2, 0.5, 0.03],
+"movement": { 
+	"perspective" : 1000, 
+	"translateX" : 30, 
+	"translateY" : 30, 
+	"translateZ" : -50, 
+	"rotateX" : 0, 
+	"rotateY" : 0,
+	"rotateZ" : 10, 
+}</code></pre>
+						</div>
+					</li>
 				</ul>
 			</div>
 			<div class="content">

--- a/index.html
+++ b/index.html
@@ -139,6 +139,30 @@
 }</code></pre>
 						</div>
 					</li>
+					<li class="grid__item">
+						<div class="grid__img grid__img--border">
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : "body" } }' alt="grid01" />
+						</div>
+						<div class="grid__item-title">
+						Demo resetOnLeave with element.mouseMoveWatcher. Options:
+<pre><code>"extraImgs" : 2,
+"opacity" : 0.7,
+"bgfixed" : false,
+"resetOnLeave" : false,
+"movement": {
+	"perspective" : 1000,
+	"translateX" : 30,
+	"translateY" : 30,
+	"translateZ" : -50,
+	"rotateX" : 0,
+	"rotateY" : 0,
+	"rotateZ" : 10,
+},
+"element" : {
+	"mouseMoveWatcher" : "body",
+}</code></pre>
+						</div>
+					</li>
 				</ul>
 			</div>
 			<div class="content">

--- a/index.html
+++ b/index.html
@@ -105,8 +105,13 @@
 				<dl class="def-list">
 					<dt><strong>extraImgs</strong></dt>
 					<dd>
-						<p>Number of extra background-image divisions; min:1, max:5</p>
+						<p>Number of extra background-image divisions; min:1, max:64</p>
 						<p><code>extraImgs : 2</code></p>
+					</dd>
+					<dt><strong>extraImgsScaleGrade</strong></dt>
+					<dd>
+						<p>Float number for set scale gradient. This option create effect like tunnel or add more perspective</p>
+						<p><code>extraImgsScaleGrade : 0</code></p>
 					</dd>
 					<dt><strong>opacity</strong></dt>
 					<dd>
@@ -117,6 +122,11 @@
 					<dd>
 						<p>Movement of first layer; by default it's not moving</p>
 						<p><code>bgfixed : true</code></p>
+					</dd>
+					<dt><strong>resetOnLeave</strong></dt>
+					<dd>
+						<p>If true when mouse leave detect area style of images will be reset to zero state</p>
+						<p><code>resetOnLeave : true</code></p>
 					</dd>
 					<dt><strong>movement</strong></dt>
 					<dd>
@@ -157,6 +167,25 @@
 							<dd>
 								<p>The relative rotation on the Z-axis. A perspective value needs to be set.</p>
 								<p><code>rotateZ : 0</code></p>
+							</dd>
+						</dl>
+					</dd>
+					<dt><strong>element</strong></dt>
+					<dd>
+						<p>Element config make possible set detect area from css selectors</p>
+						<p><code>element : { ... }</code></p>
+						<dl class="def-list">
+							<dt><strong>mouseMoveWatcher</strong></dt>
+							<dd>
+								<p>The mouseMoveWatcher set css selector with element what catch mouse move events.</p>
+								<p>As example, you can set 'body' for detect mouse move on whole page</p>
+								<p><code>mouseMoveWatcher : null|string</code></p>
+							</dd>
+							<dt><strong>viewWatcher</strong></dt>
+							<dd>
+								<p>The viewWatcher is css selector for calculate element relative offsets of extra images.</p>
+								<p>As example, this may be one block of your page with height about 100vh</p>
+								<p><code>viewWatcher : null|string</code></p>
 							</dd>
 						</dl>
 					</dd>

--- a/index.html
+++ b/index.html
@@ -162,6 +162,25 @@
 }</code></pre>
 						</div>
 					</li>
+					<li class="grid__item">
+						<div class="grid__img grid__img--border">
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : false, "bgfixed" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 } }' alt="grid01" />
+						</div>
+						<div class="grid__item-title">
+						Demo without create ext images. Options:
+<pre><code>"extraImgs" : false,
+"bgfixed" : false,
+"movement": {
+	"perspective" : 1000,
+	"translateX" : 30,
+	"translateY" : 30,
+	"translateZ" : -50,
+	"rotateX" : 0,
+	"rotateY" : 0,
+	"rotateZ" : 10,
+}</code></pre>
+						</div>
+					</li>
 				</ul>
 			</div>
 			<div class="content">

--- a/index.html
+++ b/index.html
@@ -139,16 +139,15 @@
 }</code></pre>
 						</div>
 					</li>
-					<li class="grid__item">
+					<li class="grid__item" id="demo-mouseMoveWatcher">
 						<div class="grid__img grid__img--border">
-							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : ".grid.grid--xray" } }' alt="grid01" />
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : "#demo-mouseMoveWatcher" } }' alt="grid01" />
 						</div>
 						<div class="grid__item-title">
-						Demo resetOnLeave with element.mouseMoveWatcher. Options:
+						Demo element.mouseMoveWatcher. Options:
 <pre><code>"extraImgs" : 2,
 "opacity" : 0.7,
 "bgfixed" : false,
-"resetOnLeave" : false,
 "movement": {
 	"perspective" : 1000,
 	"translateX" : 30,
@@ -159,7 +158,7 @@
 	"rotateZ" : 10,
 },
 "element" : {
-	"mouseMoveWatcher" : ".grid.grid--xray",
+	"mouseMoveWatcher" : "#demo-mouseMoveWatcher",
 }</code></pre>
 						</div>
 					</li>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,27 @@
 }</code></pre>
 						</div>
 					</li>
+					<li class="grid__item">
+						<div class="grid__img grid__img--border">
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 } }' alt="grid01" />
+						</div>
+						<div class="grid__item-title">
+						Demo resetOnLeave. Options:
+<pre><code>"extraImgs" : 2,
+"opacity" : 0.7,
+"bgfixed" : false,
+"resetOnLeave" : false,
+"movement": { 
+	"perspective" : 1000, 
+	"translateX" : 30, 
+	"translateY" : 30, 
+	"translateZ" : -50, 
+	"rotateX" : 0, 
+	"rotateY" : 0,
+	"rotateZ" : 10, 
+}</code></pre>
+						</div>
+					</li>
 				</ul>
 			</div>
 			<div class="content">

--- a/index.html
+++ b/index.html
@@ -97,6 +97,27 @@
 }</code></pre>
 						</div>
 					</li>
+					<li class="grid__item">
+						<div class="grid__img grid__img--border">
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "extraImgsScaleGrade": -0.05, "opacity" : 0.7, "bgfixed" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 } }' alt="grid01" />
+						</div>
+						<div class="grid__item-title">
+						Demo extraImgsScaleGrade. Options:
+<pre><code>"extraImgs" : 2,
+"extraImgsScaleGrade": -0.05,
+"opacity" : 0.7,
+"bgfixed" : false,
+"movement": { 
+	"perspective" : 1000, 
+	"translateX" : 30, 
+	"translateY" : 30, 
+	"translateZ" : -50, 
+	"rotateX" : 0, 
+	"rotateY" : 0,
+	"rotateZ" : 10, 
+}</code></pre>
+						</div>
+					</li>
 				</ul>
 			</div>
 			<div class="content">

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
 					</li>
 					<li class="grid__item">
 						<div class="grid__img grid__img--border">
-							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : "body" } }' alt="grid01" />
+							<img src="img/2.jpg" class="tilt-effect" data-tilt-options='{ "extraImgs" : 2, "opacity" : 0.7, "bgfixed" : false, "resetOnLeave" : false, "movement": { "perspective" : 1000, "translateX" : 30, "translateY" : 30, "translateZ" : -50, "rotateX" : 3, "rotateY" : 3, "rotateZ" : 10 }, "element" : { "mouseMoveWatcher" : ".grid.grid--xray" } }' alt="grid01" />
 						</div>
 						<div class="grid__item-title">
 						Demo resetOnLeave with element.mouseMoveWatcher. Options:
@@ -159,7 +159,7 @@
 	"rotateZ" : 10,
 },
 "element" : {
-	"mouseMoveWatcher" : "body",
+	"mouseMoveWatcher" : ".grid.grid--xray",
 }</code></pre>
 						</div>
 					</li>

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -115,6 +115,8 @@
 	TiltFx.prototype.options = {
 		// number of extra image elements (div with background-image) to add to the DOM - min:1, max:5 (for a higher number, it's recommended to remove the transitions of .tilt__front in the stylesheet.
 		extraImgs : 2,
+		// set scale factor - value what use to set scale gradients for each extra img
+		extraImgsScaleGrade: 0,
 		// the opacity value for all the image elements.
 		opacity : 0.7,
 		// by default the first layer does not move.
@@ -167,6 +169,12 @@
 
 		// add the extra image elements.
 		this.imgElems = [];
+
+		if( !this.options.bgfixed ) {
+			this.imgElems.push(this.tiltImgBack);
+			++this.options.extraImgs;
+		}
+
 		for(var i = 0; i < this.options.extraImgs; ++i) {
 			var el = document.createElement('div');
 			el.className = 'tilt__front';
@@ -174,11 +182,6 @@
 			el.style.opacity = this.options.opacity;
 			this.tiltWrapper.appendChild(el);
 			this.imgElems.push(el);
-		}
-
-		if( !this.options.bgfixed ) {
-			this.imgElems.push(this.tiltImgBack);
-			++this.options.extraImgs;
 		}
 
 		// add it to the DOM and remove original img element.
@@ -261,10 +264,26 @@
 						rotZ = moveOpts.rotateZ ? 2 * ((i+1)*moveOpts.rotateZ/self.options.extraImgs) / self.view.width * relmousepos.x - ((i+1)*moveOpts.rotateZ/self.options.extraImgs) : 0,
 						transX = moveOpts.translateX ? 2 * ((i+1)*moveOpts.translateX/self.options.extraImgs) / self.view.width * relmousepos.x - ((i+1)*moveOpts.translateX/self.options.extraImgs) : 0,
 						transY = moveOpts.translateY ? 2 * ((i+1)*moveOpts.translateY/self.options.extraImgs) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateY/self.options.extraImgs) : 0,
-						transZ = moveOpts.translateZ ? 2 * ((i+1)*moveOpts.translateZ/self.options.extraImgs) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateZ/self.options.extraImgs) : 0;
+						transZ = moveOpts.translateZ ? 2 * ((i+1)*moveOpts.translateZ/self.options.extraImgs) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateZ/self.options.extraImgs) : 0,
 
-					el.style.WebkitTransform = 'perspective(' + moveOpts.perspective + 'px) translate3d(' + transX + 'px,' + transY + 'px,' + transZ + 'px) rotate3d(1,0,0,' + rotX + 'deg) rotate3d(0,1,0,' + rotY + 'deg) rotate3d(0,0,1,' + rotZ + 'deg)';
-					el.style.transform = 'perspective(' + moveOpts.perspective + 'px) translate3d(' + transX + 'px,' + transY + 'px,' + transZ + 'px) rotate3d(1,0,0,' + rotX + 'deg) rotate3d(0,1,0,' + rotY + 'deg) rotate3d(0,0,1,' + rotZ + 'deg)';
+						scale = 1 + (self.options.extraImgsScaleGrade * (len - (i+1))),
+						scaleCss = (scale !== 1) ? ' scale(' + scale + ', ' + scale + ')' : '';
+
+					el.style.WebkitTransform =
+						'perspective(' + moveOpts.perspective + 'px)' +
+						' translate3d(' + transX + 'px,' + transY + 'px,' + transZ + 'px)' +
+						' rotate3d(1,0,0,' + rotX + 'deg)' +
+						' rotate3d(0,1,0,' + rotY + 'deg)' +
+						' rotate3d(0,0,1,' + rotZ + 'deg)' +
+						scaleCss;
+
+					el.style.transform =
+						'perspective(' + moveOpts.perspective + 'px)' +
+						' translate3d(' + transX + 'px,' + transY + 'px,' + transZ + 'px)' +
+						' rotate3d(1,0,0,' + rotX + 'deg)' +
+						' rotate3d(0,1,0,' + rotY + 'deg)' +
+						' rotate3d(0,0,1,' + rotZ + 'deg)' +
+						scaleCss;
 				}
 			});
 		});

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -305,7 +305,7 @@
 		// window resize
 		window.addEventListener('resize', throttle(function() {
 			// recalculate viewWatcher properties: width/height/left/top
-			this._calcView(this);
+			self._calcView(self);
 		}, 50));
 	};
 

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -169,13 +169,14 @@
 
 		// add the extra image elements.
 		this.imgElems = [];
+		var frontExtraImagesCount = this.options.extraImgs;
 
 		if( !this.options.bgfixed ) {
 			this.imgElems.push(this.tiltImgBack);
 			++this.options.extraImgs;
 		}
 
-		for(var i = 0; i < this.options.extraImgs; ++i) {
+		for(var i = 0; i < frontExtraImagesCount; ++i) {
 			var el = document.createElement('div');
 			el.className = 'tilt__front';
 			el.style.backgroundImage = 'url(' + this.el.src + ')';
@@ -183,6 +184,7 @@
 			this.tiltWrapper.appendChild(el);
 			this.imgElems.push(el);
 		}
+		console.log('this.imgElems', this.options, this.imgElems);
 
 		// add it to the DOM and remove original img element.
 		this.el.parentNode.insertBefore(this.tiltWrapper, this.el);

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -157,10 +157,13 @@
 
 		// image elements limit.
 		if( this.options.extraImgs < 1 ) {
-			this.options.extraImgs = 1;
+			this.imgCount = 0;
 		}
 		else if( this.options.extraImgs > 64 ) {
-			this.options.extraImgs = 64;
+			this.imgCount = 64;
+		}
+		else {
+			this.imgCount = this.options.extraImgs;
 		}
 
 		if( !this.options.movement.perspective ) {
@@ -169,11 +172,11 @@
 
 		// add the extra image elements.
 		this.imgElems = [];
-		var frontExtraImagesCount = this.options.extraImgs;
+		var frontExtraImagesCount = this.imgCount;
 
 		if( !this.options.bgfixed ) {
 			this.imgElems.push(this.tiltImgBack);
-			++this.options.extraImgs;
+			++this.imgCount;
 		}
 
 		for(var i = 0; i < frontExtraImagesCount; ++i) {
@@ -184,7 +187,6 @@
 			this.tiltWrapper.appendChild(el);
 			this.imgElems.push(el);
 		}
-		console.log('this.imgElems', this.options, this.imgElems);
 
 		// add it to the DOM and remove original img element.
 		this.el.parentNode.insertBefore(this.tiltWrapper, this.el);
@@ -250,7 +252,10 @@
 					// mouse position relative to the document.
 				var mousepos = getMousePos(ev),
 					// document scrolls.
-					docScrolls = {left : document.body.scrollLeft + document.documentElement.scrollLeft, top : document.body.scrollTop + document.documentElement.scrollTop},
+					docScrolls = {
+						left : document.body.scrollLeft + document.documentElement.scrollLeft,
+						top : document.body.scrollTop + document.documentElement.scrollTop
+					},
 					bounds = self.tiltWrapper.getBoundingClientRect(),
 					// mouse position relative to the main element (tiltWrapper).
 					relmousepos = {
@@ -261,12 +266,12 @@
 				// configure the movement for each image element.
 				for(var i = 0, len = self.imgElems.length; i < len; ++i) {
 					var el = self.imgElems[i],
-						rotX = moveOpts.rotateX ? 2 * ((i+1)*moveOpts.rotateX/self.options.extraImgs) / self.view.height * relmousepos.y - ((i+1)*moveOpts.rotateX/self.options.extraImgs) : 0,
-						rotY = moveOpts.rotateY ? 2 * ((i+1)*moveOpts.rotateY/self.options.extraImgs) / self.view.width * relmousepos.x - ((i+1)*moveOpts.rotateY/self.options.extraImgs) : 0,
-						rotZ = moveOpts.rotateZ ? 2 * ((i+1)*moveOpts.rotateZ/self.options.extraImgs) / self.view.width * relmousepos.x - ((i+1)*moveOpts.rotateZ/self.options.extraImgs) : 0,
-						transX = moveOpts.translateX ? 2 * ((i+1)*moveOpts.translateX/self.options.extraImgs) / self.view.width * relmousepos.x - ((i+1)*moveOpts.translateX/self.options.extraImgs) : 0,
-						transY = moveOpts.translateY ? 2 * ((i+1)*moveOpts.translateY/self.options.extraImgs) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateY/self.options.extraImgs) : 0,
-						transZ = moveOpts.translateZ ? 2 * ((i+1)*moveOpts.translateZ/self.options.extraImgs) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateZ/self.options.extraImgs) : 0,
+						rotX = moveOpts.rotateX ? 2 * ((i+1)*moveOpts.rotateX/self.imgCount) / self.view.height * relmousepos.y - ((i+1)*moveOpts.rotateX/self.imgCount) : 0,
+						rotY = moveOpts.rotateY ? 2 * ((i+1)*moveOpts.rotateY/self.imgCount) / self.view.width * relmousepos.x - ((i+1)*moveOpts.rotateY/self.imgCount) : 0,
+						rotZ = moveOpts.rotateZ ? 2 * ((i+1)*moveOpts.rotateZ/self.imgCount) / self.view.width * relmousepos.x - ((i+1)*moveOpts.rotateZ/self.imgCount) : 0,
+						transX = moveOpts.translateX ? 2 * ((i+1)*moveOpts.translateX/self.imgCount) / self.view.width * relmousepos.x - ((i+1)*moveOpts.translateX/self.imgCount) : 0,
+						transY = moveOpts.translateY ? 2 * ((i+1)*moveOpts.translateY/self.imgCount) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateY/self.imgCount) : 0,
+						transZ = moveOpts.translateZ ? 2 * ((i+1)*moveOpts.translateZ/self.imgCount) / self.view.height * relmousepos.y - ((i+1)*moveOpts.translateZ/self.imgCount) : 0,
 
 						scale = 1 + (self.options.extraImgsScaleGrade * (len - (i+1))),
 						scaleCss = (scale !== 1) ? ' scale(' + scale + ', ' + scale + ')' : '';

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -128,6 +128,13 @@
 			rotateX : 2, // a relative rotation of -2deg to 2deg on the x-axis (perspective value must be set)
 			rotateY : 2, // a relative rotation of -2deg to 2deg on the y-axis (perspective value must be set)
 			rotateZ : 0 // z-axis rotation; by default there's no rotation on the z-axis (perspective value must be set)
+		},
+		// element for relative custom position offset
+		element : {
+			// element what will be bind to mousemove
+			mouseMoveWatcher: null,
+			// element for set bounds of mousemove
+			viewWatcher: null
 		}
 	}
 

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -104,7 +104,7 @@
 	 * @param {object} options
 	 */
 	function TiltFx(el, options) {
-			if(el) {
+		if(el) {
 			this.el = el;
 			this.options = extend( {}, this.options );
 			extend( this.options, options );

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -113,12 +113,14 @@
 	 * TiltFx options.
 	 */
 	TiltFx.prototype.options = {
-		// number of extra image elements (div with background-image) to add to the DOM - min:1, max:5 (for a higher number, it's recommended to remove the transitions of .tilt__front in the stylesheet.
+		// number of extra image elements (div with background-image) to add to the DOM - min:0, max:64 (for a higher number, it's recommended to remove the transitions of .tilt__front in the stylesheet.
 		extraImgs : 2,
 		// set scale factor - value what use to set scale gradients for each extra img
 		extraImgsScaleGrade: 0,
 		// the opacity value for all the image elements.
 		opacity : 0.7,
+		// when use set array of opacity for each image from bottom to top
+		customImgsOpacity: false,
 		// by default the first layer does not move.
 		bgfixed : true,
 		// use reset style for mouseleave event
@@ -152,6 +154,7 @@
 		// main image element.
 		this.tiltImgBack = document.createElement('div');
 		this.tiltImgBack.className = 'tilt__back';
+		this.tiltImgBack.tiltFxType = 'back';
 		this.tiltImgBack.style.backgroundImage = 'url(' + this.el.src + ')';
 		this.tiltWrapper.appendChild(this.tiltImgBack);
 
@@ -173,6 +176,7 @@
 		// add the extra image elements.
 		this.imgElems = [];
 		var frontExtraImagesCount = this.imgCount;
+		var customImgsOpacity = this.options.customImgsOpacity;
 
 		if( !this.options.bgfixed ) {
 			this.imgElems.push(this.tiltImgBack);
@@ -183,10 +187,12 @@
 			var el = document.createElement('div');
 			el.className = 'tilt__front';
 			el.style.backgroundImage = 'url(' + this.el.src + ')';
-			el.style.opacity = this.options.opacity;
 			this.tiltWrapper.appendChild(el);
 			this.imgElems.push(el);
 		}
+
+		// set opacity for images
+		this._initSetImagesOpacity();
 
 		// add it to the DOM and remove original img element.
 		this.el.parentNode.insertBefore(this.tiltWrapper, this.el);
@@ -198,6 +204,34 @@
 
 		// viewWatcher properties: width/height/left/top
 		this._calcView(this);
+	};
+
+	/**
+	 * Set images opacity.
+	 * @private
+	 */
+	TiltFx.prototype._initSetImagesOpacity = function() {
+		if(this.options.customImgsOpacity) {
+			for(var i = 0, len = this.imgElems.length; i < len; ++i) {
+				var opacity = (this.options.customImgsOpacity[i])
+					? this.options.customImgsOpacity[i]
+					: this.options.opacity;
+
+				this.imgElems[i].style.opacity = opacity;
+
+			}
+
+		}
+		else {
+			for(var i = 0, len = this.imgElems.length; i < len; ++i) {
+				if(this.imgElems[i].tiltFxType === 'back') {
+					continue;
+				}
+
+				this.imgElems[i].style.opacity = this.options.opacity;
+			}
+
+		}
 	};
 
 	TiltFx.prototype._calcView = function(self) {

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -100,13 +100,17 @@
 
 	/**
 	 * TiltFx fn
+	 * @param {HTMLElement} img element
+	 * @param {object} options
 	 */
 	function TiltFx(el, options) {
-		this.el = el;
-		this.options = extend( {}, this.options );
-		extend( this.options, options );
-		this._init();
-		this._initEvents();
+			if(el) {
+			this.el = el;
+			this.options = extend( {}, this.options );
+			extend( this.options, options );
+			this._init();
+			this._initEvents();
+		}
 	}
 
 	/**
@@ -350,14 +354,17 @@
 		}, 50));
 	};
 
-	function init() {
+	/**
+	 * Init tiltFx on each imgs with the class "tilt-effect"
+	 */
+	TiltFx.prototype.init = function() {
 		// search for imgs with the class "tilt-effect"
 		[].slice.call(document.querySelectorAll('img.tilt-effect')).forEach(function(img) {
 			new TiltFx(img, JSON.parse(img.getAttribute('data-tilt-options')));
 		});
-	}
+	};
 
-	init();
+	(new TiltFx()).init();
 
 	window.TiltFx = TiltFx;
 

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -119,6 +119,8 @@
 		opacity : 0.7,
 		// by default the first layer does not move.
 		bgfixed : true,
+		// use reset style for mouseleave event
+		resetOnLeave: true,
 		// image element's movement configuration
 		movement : {
 			perspective : 1000, // perspective value
@@ -268,16 +270,18 @@
 		});
 
 		// reset all when mouse leaves the main wrapper.
-		self.mouseMoveWatcher.addEventListener('mouseleave', function() {
-			setTimeout(function() {
-			for(var i = 0, len = self.imgElems.length; i < len; ++i) {
-				var el = self.imgElems[i];
-				el.style.WebkitTransform = 'perspective(' + moveOpts.perspective + 'px) translate3d(0,0,0) rotate3d(1,1,1,0deg)';
-				el.style.transform = 'perspective(' + moveOpts.perspective + 'px) translate3d(0,0,0) rotate3d(1,1,1,0deg)';
-			}	
-			}, 60);
-			
-		});
+		if(self.options.resetOnLeave) {
+			self.mouseMoveWatcher.addEventListener('mouseleave', function () {
+				setTimeout(function () {
+					for (var i = 0, len = self.imgElems.length; i < len; ++i) {
+						var el = self.imgElems[i];
+						el.style.WebkitTransform = 'perspective(' + moveOpts.perspective + 'px) translate3d(0,0,0) rotate3d(1,1,1,0deg)';
+						el.style.transform = 'perspective(' + moveOpts.perspective + 'px) translate3d(0,0,0) rotate3d(1,1,1,0deg)';
+					}
+				}, 60);
+
+			});
+		}
 
 		// window resize
 		window.addEventListener('resize', throttle(function() {

--- a/js/tiltfx.js
+++ b/js/tiltfx.js
@@ -148,8 +148,8 @@
 		if( this.options.extraImgs < 1 ) {
 			this.options.extraImgs = 1;
 		}
-		else if( this.options.extraImgs > 5 ) {
-			this.options.extraImgs = 5;
+		else if( this.options.extraImgs > 64 ) {
+			this.options.extraImgs = 64;
 		}
 
 		if( !this.options.movement.perspective ) {
@@ -176,8 +176,51 @@
 		this.el.parentNode.insertBefore(this.tiltWrapper, this.el);
 		this.el.parentNode.removeChild(this.el);
 
-		// tiltWrapper properties: width/height/left/top
-		this.view = { width : this.tiltWrapper.offsetWidth, height : this.tiltWrapper.offsetHeight };
+		// set mosemove element area and view restrictions
+		this._setViewWatcher(this);
+		this._setMouseMoveWatcher(this);
+
+		// viewWatcher properties: width/height/left/top
+		this._calcView(this);
+	};
+
+	TiltFx.prototype._calcView = function(self) {
+		self.view = {
+			width : self.viewWatcher.offsetWidth,
+			height : self.viewWatcher.offsetHeight
+		};
+	};
+
+	TiltFx.prototype._setMouseMoveWatcher = function(self) {
+		var isSet = false;
+
+		if(self.options.element && self.options.element.mouseMoveWatcher) {
+			var mouseMoveWatcherElement = document.querySelector(self.options.element.mouseMoveWatcher);
+
+			self.mouseMoveWatcher = mouseMoveWatcherElement;
+			isSet = true;
+		}
+
+		if(!isSet) {
+			self.mouseMoveWatcher = self.viewWatcher;
+		}
+	};
+
+	TiltFx.prototype._setViewWatcher = function(self) {
+		var isSet = false;
+
+		if(self.options.element && self.options.element.viewWatcher) {
+			var customElementRelative = document.querySelector(self.options.element.viewWatcher);
+
+			if(customElementRelative) {
+				self.viewWatcher = customElementRelative;
+				isSet = true;
+			}
+		}
+
+		if(!isSet) {
+			self.viewWatcher = self.tiltWrapper;
+		}
 	};
 
 	/**
@@ -188,7 +231,7 @@
 			moveOpts = self.options.movement;
 
 		// mousemove event..
-		this.tiltWrapper.addEventListener('mousemove', function(ev) {
+		self.mouseMoveWatcher.addEventListener('mousemove', function(ev) {
 			requestAnimationFrame(function() {
 					// mouse position relative to the document.
 				var mousepos = getMousePos(ev),
@@ -218,7 +261,7 @@
 		});
 
 		// reset all when mouse leaves the main wrapper.
-		this.tiltWrapper.addEventListener('mouseleave', function(ev) {
+		self.mouseMoveWatcher.addEventListener('mouseleave', function() {
 			setTimeout(function() {
 			for(var i = 0, len = self.imgElems.length; i < len; ++i) {
 				var el = self.imgElems[i];
@@ -230,9 +273,9 @@
 		});
 
 		// window resize
-		window.addEventListener('resize', throttle(function(ev) {
-			// recalculate tiltWrapper properties: width/height/left/top
-			self.view = { width : self.tiltWrapper.offsetWidth, height : self.tiltWrapper.offsetHeight };
+		window.addEventListener('resize', throttle(function() {
+			// recalculate viewWatcher properties: width/height/left/top
+			this._calcView(this);
 		}, 50));
 	};
 


### PR DESCRIPTION
Hi, I added new options:

- `extraImgsScaleGrade` for set different scale(x) in each elements and making tunnel effect;
- `resetOnLeave` for save transforms when mouse leave detect `mousemove` area;
- `element.mouseMoveWatcher` for custom set any `HTMLElement` what will be detect `mosemove`
this option may be helpful when you have some content above your image;
- `element.viewWatcher` for setting div what will calculate relative bounds;
- `customImgsOpacity` for custom set any opacity for each images;
- `extraImgs` was modified for set `false` if you don't need create extra images.

Example for each option you can look at here: https://rawgit.com/Dok11/ImageTiltEffect/master/index.html